### PR TITLE
use make publish instead of npm publish

### DIFF
--- a/makefile
+++ b/makefile
@@ -48,7 +48,9 @@ watch:
 tag:
 	node ./bin/tag.js
 
+publish: test prod dev tag
+
 test/build/tests.js: test/src/* src/*
 	./node_modules/.bin/webpack test/src/tests.js $@ --config test/webpack.config.js
 
-.PHONY: clean build test jenkins watch tap-test stop-server server.pid
+.PHONY: clean build test jenkins watch tap-test stop-server server.pid tag publish

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "url": "https://github.com/addthis/fluxthis"
   },
   "scripts": {
-    "test": "make test",
-    "prepublish": "make test && make prod && make dev && make tag"
+    "test": "make test"
   },
   "keywords": [
     "Flux",


### PR DESCRIPTION
`npm install` runs `prepublish` npm/npm#3059

So we're going to publish with `make publish`