### PR TITLE
Fixed debug messages

### DIFF
--- a/src/ActionCreator.es6.js
+++ b/src/ActionCreator.es6.js
@@ -204,9 +204,8 @@ class ActionCreator {
 			// This is used for more complex payload checking
 			// like instanceOf, etc.
 			else if (expected) {
-
-					err.message = this + ' ' + name + ' was provided ' +
-					'an invalid payload. Expected ' + expected + '.';
+				err.message = this + ' ' + name + ' was provided ' +
+				'an invalid payload. Expected ' + expected + '.';
 			}
 
 			throw err;

--- a/src/ActionCreator.es6.js
+++ b/src/ActionCreator.es6.js
@@ -20,9 +20,9 @@ var each = require('../lib/each');
 var PropTypes = require('react/lib/ReactPropTypes');
 var invariant = require('invariant');
 
-var RE_REQUIRED_PROP = /Required prop `(.*?)`/;
+var RE_REQUIRED_PROP = /Required prop .*`(.*?)`/;
 
-var RE_WARNING_EXPECTED = /expected `(.*?)`/;
+var RE_WARNING_EXPECTED = /expected (.*`(.*?)`)/;
 var RE_WARNING_FOUND = /type `(.*?)`/;
 
 var IN_PRODUCTION = process.env.NODE_ENV === 'production';
@@ -175,7 +175,7 @@ class ActionCreator {
 	 *	against.
 	 */
 	validatePayload (name, payload, payloadType) {
-		var err = payloadType({payload: payload}, 'payload', 'NAME', 'prop');
+		var err = payloadType({payload: payload}, 'payload', name, 'prop');
 		var expected;
 		var found;
 		var required;
@@ -194,10 +194,21 @@ class ActionCreator {
 			// Else we found a prop of one type when we expected another
 			else if (expected) {
 				expected = expected[1];
-				found = message.match(RE_WARNING_FOUND)[1];
-				err.message = this + ' ' + name + ' was provided ' +
-				'an invalid payload. Expected `' + expected + '`, got `' +
-				found + '`.';
+				found = message.match(RE_WARNING_FOUND);
+
+				if (found) {
+					// If we found something, then that means
+					// we are checking primitive payloads.
+					err.message = this + ' ' + name + ' was provided ' +
+					'an invalid payload. Expected ' + expected + ', got `' +
+					found[1] + '`.';
+				} else {
+					// This is used for more complex payload checking
+					// like instanceOf, etc.
+					err.message = this + ' ' + name + ' was provided ' +
+					'an invalid payload. Expected ' + expected + '.';
+				}
+
 			}
 
 			throw err;

--- a/src/ActionCreator.es6.js
+++ b/src/ActionCreator.es6.js
@@ -185,6 +185,7 @@ class ActionCreator {
 
 			required = message.match(RE_REQUIRED_PROP);
 			expected = message.match(RE_WARNING_EXPECTED);
+			found = message.match(RE_WARNING_FOUND);
 
 			// If the message is that it's missing a required prop
 			if (required) {
@@ -192,23 +193,20 @@ class ActionCreator {
 					'the required prop `' + required[1] + '`.';
 			}
 			// Else we found a prop of one type when we expected another
-			else if (expected) {
+			else if (expected && found) {
 				expected = expected[1];
 				found = message.match(RE_WARNING_FOUND);
 
-				if (found) {
-					// If we found something, then that means
-					// we are checking primitive payloads.
-					err.message = this + ' ' + name + ' was provided ' +
-					'an invalid payload. Expected ' + expected + ', got `' +
-					found[1] + '`.';
-				} else {
-					// This is used for more complex payload checking
-					// like instanceOf, etc.
+				err.message = this + ' ' + name + ' was provided ' +
+				'an invalid payload. Expected ' + expected + ', got `' +
+				found[1] + '`.';
+			}
+			// This is used for more complex payload checking
+			// like instanceOf, etc.
+			else if (expected) {
+
 					err.message = this + ' ' + name + ' was provided ' +
 					'an invalid payload. Expected ' + expected + '.';
-				}
-
 			}
 
 			throw err;

--- a/src/ActionCreator.es6.js
+++ b/src/ActionCreator.es6.js
@@ -20,7 +20,7 @@ var each = require('../lib/each');
 var PropTypes = require('react/lib/ReactPropTypes');
 var invariant = require('invariant');
 
-var RE_REQUIRED_PROP = /Required prop .*`(.*?)`/;
+var RE_REQUIRED_PROP = /Required prop `(.*?)`/;
 
 var RE_WARNING_EXPECTED = /expected (.*`(.*?)`)/;
 var RE_WARNING_FOUND = /type `(.*?)`/;


### PR DESCRIPTION
We had some issues with our debug messages because we were not checking for the valid messages returned from React's library. 

There was two different types of strings that were returned when we find 'expected'. One is for primitives and the other is for more complex objects (like instanceOf, arrays, etc). We were missing the second check. 