### PR TITLE
API Refactor & Fixed a bug in createRequest

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -109,7 +109,7 @@ gulp.task('clean', function () {
 gulp.task('lint', function () {
     // Note: To have the process exit with an error code (1) on
     //  lint error, return the stream and pipe to failOnError last.
-    return gulp.src(['src/**/*.js'])
+    return gulp.src(['src/**/*.js', 'lib/**/*.js'])
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failOnError());

--- a/lib/each.js
+++ b/lib/each.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 /**
  * Iterates over `collection`, passing each key and value to `callback`. If
  * `callback` returns false, the loop will be broken early.

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -35,8 +35,7 @@ module.exports = implore;
  * XHR wrapper for same-domain requests with Content-Type: application/json
  *
  * @param {request} request
- * @param {function} callback - called with (request, response) on completion or
- *	error
+ * @return {Promise}
  */
 function implore (request) {
 	return new Promise(resolve => {
@@ -59,7 +58,6 @@ function implore (request) {
 			typeof request.method === 'string',
 			'implore requires parameter `method` to be a string'
 		);
-
 
 		xhr = new XMLHttpRequest();
 		xhr.open(request.method, getURLFromRequest(request));
@@ -124,30 +122,31 @@ function implore (request) {
 	})
 }
 
-implore.get = function (options, callback) {
+implore.get = function (options) {
 	options.method = 'GET';
-	return implore(options, callback);
+	return implore(options);
 };
 
-implore.post = function (options, callback) {
+implore.post = function (options) {
 	options.method = 'POST';
-	return implore(options, callback);
+	return implore(options);
 };
 
-implore.put = function (options, callback) {
+implore.put = function (options) {
 	options.method = 'PUT';
-	return implore(options, callback);
+	return implore(options);
 };
 
-implore.delete = function (options, callback) {
+implore.delete = function (options) {
 	options.method = 'DELETE';
-	return implore(options, callback);
+	return implore(options);
 };
 
 /**
  * Combine the route/params/query of a request into a complete URL
  * 
- * @param {request} request,
+ * @param {request} request
+ * @param {object|array} request.query
  * @return {string} url
  */
 function getURLFromRequest (request) {
@@ -175,7 +174,7 @@ function getURLFromRequest (request) {
  * @param {string} prefix - used in recursive calls to keep track of the parent
  * @return {string} queryString without the '?''
  */
-function makeQueryString (obj, prefix) {
+function makeQueryString (obj, prefix='') {
 	var str = [];
 	var prop;
 	var key;

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -38,87 +38,90 @@ module.exports = implore;
  * @param {function} callback - called with (request, response) on completion or
  *	error
  */
-function implore (request, callback) {
-	var response = {
-		error: null
-	};
-	var xhr;
-	
-	invariant(
-		request,
-		'implore requires a `request` argument'
-	);
+function implore (request) {
+	return new Promise(resolve => {
+		var response = {
+			error: null
+		};
+		var xhr;
 
-	invariant(
-		typeof request.route === 'string',
-		'implore requires parameter `route` to be a string'
-	);
+		invariant(
+			request,
+			'implore requires a `request` argument'
+		);
 
-	invariant(
-		typeof request.method === 'string',
-		'implore requires parameter `method` to be a string'
-	);
+		invariant(
+			typeof request.route === 'string',
+			'implore requires parameter `route` to be a string'
+		);
+
+		invariant(
+			typeof request.method === 'string',
+			'implore requires parameter `method` to be a string'
+		);
 
 
-	xhr = new XMLHttpRequest();	
-	xhr.open(request.method, getURLFromRequest(request));
+		xhr = new XMLHttpRequest();
+		xhr.open(request.method, getURLFromRequest(request));
 
-	switch (request.method) {
-		case 'POST':
-		case 'PUT':
-		case 'PATCH':
-			xhr.setRequestHeader('Content-Type','application/json');
-			break;
-	}
-	
-	xhr.onreadystatechange = function () {
-		var responseText;
-		var firstChar;
-		var lastChar;
+		switch (request.method) {
+			case 'POST':
+			case 'PUT':
+			case 'PATCH':
+				xhr.setRequestHeader('Content-Type','application/json');
+				break;
+		}
 
-		if(xhr.readyState === 4) {
-			responseText = xhr.responseText;
-			firstChar = responseText.charAt(0);
-			lastChar = responseText.charAt(responseText.length - 1);
-			
-			response.status = xhr.status;
-			response.type = xhr.getResponseHeader('Content-Type');
+		xhr.onreadystatechange = function () {
+			var responseText;
 
-			if(response.type === 'application/json') {
-				try {
-					response.body = JSON.parse(responseText);
-				}
-				catch (err) {
-					err.message = err.message + ' while parsing `' +
+			if(xhr.readyState === 4) {
+				responseText = xhr.responseText;
+				response.status = xhr.status;
+				response.type = xhr.getResponseHeader('Content-Type');
+
+				if(response.type === 'application/json') {
+					try {
+						response.body = JSON.parse(responseText);
+					}
+					catch (err) {
+						err.message = err.message + ' while parsing `' +
 						responseText + '`';
-					response.body = {};
-					response.status = xhr.status || 0;
-					response.error = err;
+						response.body = {};
+						response.status = xhr.status || 0;
+						response.error = err;
+					}
 				}
+				else {
+					response.body = responseText;
+				}
+
+				return resolve({
+					request,
+					response
+				});
+			}
+		};
+
+		try {
+			if(request.body) {
+				xhr.send(JSON.stringify(request.body));
 			}
 			else {
-				response.body = responseText;
-			}
-			
-			if(callback) {
-				callback(request, response);
+				xhr.send();
 			}
 		}
-	};
+		catch (err) {
+			response.body = {};
+			response.status = 0;
+			response.error = err;
 
-	try {
-		if(request.body) {
-			xhr.send(JSON.stringify(request.body));
+			return resolve({
+				request,
+				response
+			});
 		}
-		else {
-			xhr.send();
-		}
-	}
-	catch (err) {
-		response.body = {};
-		response.status = 0;
-		response.error = err;
-	}
+	})
 }
 
 implore.get = function (options, callback) {

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -16,8 +16,6 @@
 
 var invariant = require('invariant');
 
-module.exports = implore;
-
 /**
  * @typedef {object} request
  * @property {string} method
@@ -39,7 +37,7 @@ module.exports = implore;
  * @param {request} request
  * @return {Promise}
  */
-function implore (request) {
+export default function implore (request) {
 	return new Promise(resolve => {
 		var response = {
 			error: null
@@ -86,7 +84,7 @@ function implore (request) {
 					}
 					catch (err) {
 						err.message = err.message + ' while parsing `' +
-						responseText + '`';
+							responseText + '`';
 						response.body = {};
 						response.status = xhr.status || 0;
 						response.error = err;

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -11,7 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
+'use strict';
+
 var invariant = require('invariant');
 
 module.exports = implore;
@@ -66,7 +68,7 @@ function implore (request) {
 			case 'POST':
 			case 'PUT':
 			case 'PATCH':
-				xhr.setRequestHeader('Content-Type','application/json');
+				xhr.setRequestHeader('Content-Type', 'application/json');
 				break;
 		}
 
@@ -119,7 +121,7 @@ function implore (request) {
 				response
 			});
 		}
-	})
+	});
 }
 
 implore.get = function (options) {
@@ -144,7 +146,7 @@ implore.delete = function (options) {
 
 /**
  * Combine the route/params/query of a request into a complete URL
- * 
+ *
  * @param {request} request
  * @param {object|array} request.query
  * @return {string} url
@@ -169,7 +171,7 @@ function getURLFromRequest (request) {
 
 /**
  * Take a simple object and turn it into a queryString, recursively.
- * 
+ *
  * @param {object} obj - query object
  * @param {string} prefix - used in recursive calls to keep track of the parent
  * @return {string} queryString without the '?''
@@ -182,9 +184,9 @@ function makeQueryString (obj, prefix='') {
 
 	for(prop in obj) {
 		if (obj.hasOwnProperty(prop)) {
-			key = prefix ? 
-				prefix + '[' + prop + ']' : 
-				prop; 
+			key = prefix ?
+				prefix + '[' + prop + ']' :
+				prop;
 			value = obj[prop];
 			str.push(typeof value === 'object' ?
 				makeQueryString(value, key) :

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -148,10 +148,13 @@ export default class APIActionCreator extends ActionCreator {
 					var {response, request} = result;
 					var success = successTest(response);
 
+					// These methods allow the user to process
+					// the request and modify it how they please
+					// or dispatch more actions.
 					if (success && handleSuccess) {
 						handleSuccess.call(this, request, response);
 					}
-					else if (!success && handleFailure) {
+					else if (handleFailure) {
 						handleFailure.call(this, request, response);
 					}
 

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -128,6 +128,7 @@ export default class APIActionCreator extends ActionCreator {
 
 			this.validatePayload(name, request, payloadType);
 
+			// Setup pending action.
 			action = {
 				source: actionSource,
 				type: pendingActionType,
@@ -140,22 +141,21 @@ export default class APIActionCreator extends ActionCreator {
 				dispatcher.dispatch(action);
 			}
 
+
+
 			send(request)
 				.then(result => {
 					var {response, request} = result;
 					var success = successTest(response);
-					var action;
 
-					// These methods allow the user to process
-					// the request and modify it how they please
-					// or dispatch more actions.
 					if (success && handleSuccess) {
 						handleSuccess.call(this, request, response);
 					}
-					else if (handleFailure) {
+					else if (!success && handleFailure) {
 						handleFailure.call(this, request, response);
 					}
 
+					// Setup action for success/failure
 					action = {
 						source: actionSource,
 						type: success ? successActionType : failureActionType,
@@ -165,10 +165,9 @@ export default class APIActionCreator extends ActionCreator {
 						}
 					};
 
-					// Finally, lets dispatch the action if the user
-					// specified the required conditionals.
-					if ((success && successActionType) ||
-						(!success && failureActionType)) {
+					// If we reach the end and we have an action
+					// type, then that means we need to dispatch.
+					if (action.type) {
 						dispatcher.dispatch(action);
 					}
 				});

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -58,7 +58,6 @@ export default class APIActionCreator extends ActionCreator {
 			APIActionCreator.defaultSuccessTest;
 
 		var payloadType = ActionCreator.PayloadTypes.shape({
-			route: ActionCreator.PayloadTypes.string.isRequired,
 			body: ActionCreator.PayloadTypes.object,
 			query: ActionCreator.PayloadTypes.object,
 			params: ActionCreator.PayloadTypes.object
@@ -91,7 +90,7 @@ export default class APIActionCreator extends ActionCreator {
 		);
 
 		invariant(
-			typeof description.route === 'string',
+			typeof description.route === 'string' || description.route,
 			'The method `%s` could not be created on `%s`; ' +
 			'`route` must be a `string`, like "/example/:example"',
 			name,

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -38,22 +38,6 @@ export default class APIActionCreator extends ActionCreator {
 		response.status < 300;
 	}
 
-	/**
-	 * Given a route string, get the expected argument names from it
-	 *
-	 * @param {string} route - a route e.g. '/abc/:def/ghi/:hi'
-	 * @return {string[]} - list of url param names e.g. ['def','hi']
-	 */
-	static getURLParamsFromRoute (route) {
-		var match;
-		var regexp = /\/:([^:\/]+)/g;
-		var args = [];
-		while((match = regexp.exec(route)) !== null) {
-			args.push(match);
-		}
-		return args;
-	}
-
 	constructor (options) {
 		super(options, {successTest: 1});
 	}

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -126,6 +126,14 @@ export default class APIActionCreator extends ActionCreator {
 			var action;
 			var request;
 
+			invariant(
+				createRequest || args.length === 0,
+				`${this.toString()}'s ${name} action received ` +
+				'arguments without a `createRequest` method. You must ' +
+				'provide a `createRequest` method so you can format ' +
+				'these arguments in the request.'
+			);
+
 			if (createRequest) {
 				request = createRequest.apply(this, args);
 			}

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -16,7 +16,7 @@
 
 var dispatcher = require('./dispatcherInstance.es6');
 var invariant = require('invariant');
-var implore = require('../lib/implore.es6');
+var send = require('../lib/implore.es6');
 var debug = require('./debug.es6');
 var ActionCreator = require('./ActionCreator.es6');
 
@@ -140,7 +140,7 @@ export default class APIActionCreator extends ActionCreator {
 				dispatcher.dispatch(action);
 			}
 
-			implore(request)
+			send(request)
 				.then(result => {
 					var {response, request} = result;
 					var success = successTest(response);

--- a/test/src/api-action-creator-tests.js
+++ b/test/src/api-action-creator-tests.js
@@ -79,6 +79,8 @@ describe('APIActionCreators', function () {
 
     it('should transform a request with createRequest', function (done) {
         var query = {};
+		var clonedQuery = {};
+
         var aac = new APIActionCreator({
             actionSource: 'apiSource4',
 			displayName: 'api4',
@@ -89,14 +91,18 @@ describe('APIActionCreators', function () {
                 createRequest: function (a, b) {
                     query.a = a;
                     query.b = b;
+
+					// setup cloned query for equality
+					clonedQuery.a = a;
+					clonedQuery.b = b;
                     return {
                         query: query
                     };
                 },
                 handleSuccess: function (req, res) {
                     try {
-                        req.query.should.eql(query);
-                        res.body.query.should.eql(query);
+                        req.query.should.eql(clonedQuery);
+                        res.body.query.should.eql(clonedQuery);
                         done();
                     }
                     catch(err) {

--- a/test/src/api-action-creator-tests.js
+++ b/test/src/api-action-creator-tests.js
@@ -115,8 +115,23 @@ describe('APIActionCreators', function () {
             }
         });
 
-        aac.doThing('hi','mom');
+        aac.doThing('hi', 'mom');
     });
+
+	it('should throw an error for passing args without create request', function () {
+		(function () {
+			var aac = new APIActionCreator({
+				actionSource: 'apiSource55',
+				displayName: 'api55',
+				doThing: {
+					route: '/mirror',
+					method: 'POST',
+					pending: 'TEST_' + Math.random()
+				}
+			});
+			aac.doThing('hi', 'mom');
+		}).should.throw();
+	});
 
     it('should throw errors when route is missing', function () {
         (function () {
@@ -215,7 +230,7 @@ describe('APIActionCreators', function () {
                 }
             });
 
-            aac.doBrokenThing('hi','mom');
+            aac.doBrokenThing();
         });
     });
 


### PR DESCRIPTION
I did a slight refactor on the API / Implore (promises really). Updated / added comments. Cleaned up some conditional logic to reduce indentations. 

We were checking route with an invariant to see if it was a string, then passing it to check payload to validate it wasn't empty. I removed that check and added it to the invariant. 

Now to the bug with createRequest:
There was an issue with how the logic was setup as Jake and I discussed. The request parameter was not actually the request, but rather the first parameter passed to the action creator's method while submitting an action. To fix this problem got rid of `(request, ...args)` in favor of `(...args)` and also added validation to ensure that if we are passing arguments to an API action creator that the user implemented `createRequest` to format those parameters appropriately. 