### PR TITLE
Added optimizations to dispatching

### DIFF
--- a/src/Dispatcher.es6.js
+++ b/src/Dispatcher.es6.js
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 'use strict';
 
 var invariant = require('invariant');
+var debug = require('./debug.es6');
 
 var _lastID = 1;
 var _prefix = 'ID_';
@@ -52,6 +53,8 @@ export default class Dispatcher {
 		this[CALLBACKS] = {};
 		this[IS_PENDING] = {};
 		this[IS_HANDLED] = {};
+		// Using a Map for this allows us to support
+		// ConstantCollections as keys.
 		this[STORE_ACTIONS] = new Map();
 		this[LEGACY_STORES] = [];
 
@@ -287,7 +290,7 @@ function invokeCallback (id) {
  * @internal
  */
 function startDispatching (action) {
-	require('./debug.es6').logDispatch(action);
+	debug.logDispatch(action);
 
 	for (var id in this[CALLBACKS]) {
 		this[IS_PENDING][id] = false;

--- a/src/Dispatcher.es6.js
+++ b/src/Dispatcher.es6.js
@@ -33,7 +33,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 'use strict';
 
 var invariant = require('invariant');
-var debug = require('./debug.es6');
 
 var _lastID = 1;
 var _prefix = 'ID_';
@@ -290,7 +289,7 @@ function invokeCallback (id) {
  * @internal
  */
 function startDispatching (action) {
-	debug.logDispatch(action);
+	require('./debug.es6').logDispatch(action);
 
 	for (var id in this[CALLBACKS]) {
 		this[IS_PENDING][id] = false;

--- a/src/ObjectOrientedStore.es6.js
+++ b/src/ObjectOrientedStore.es6.js
@@ -212,7 +212,11 @@ export default class ObjectOrientedStore extends Store {
 						};
 					}
 
-					store.dispatchToken = dispatcher.register(dispatchFunction);
+					// Register the store with the Dispatcher
+					store.dispatchToken = dispatcher.register(
+						dispatchFunction,
+						actions
+					);
 				}
 			}
 		});


### PR DESCRIPTION
Optimize all the things... except... there is one downside to this optimization. The deregister isn't that optimized because I don't iterate over all the registered actions to remove the store. The reason is because the complexity to do this is pretty high and we don't ever deregister stores.... so i left it how it is. Since you have to iterate over every action (n), then search the index for the store_id (n). So it's o(n^2).