### PR TITLE
Refactored to work with ES6 restrictions

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('mocha-test', function () {
     return stream;
 });
 
-gulp.task('build-test', function (callback) {
+gulp.task('build-test', function () {
     testWebpackConfig.plugins = testWebpackConfig.plugins.concat(
         new webpack.DefinePlugin({
             'process.env': {
@@ -66,13 +66,13 @@ gulp.task('test', function(callback) {
         callback);
 });
 
-gulp.task('build-dev', function (callback) {
+gulp.task('build-dev', function () {
     return gulp.src(webpackConfig.entry.FluxThis)
         .pipe(gulpWebpack(webpackConfig))
         .pipe(gulp.dest(webpackConfig.output.path));
 });
 
-gulp.task('build-prod', function (callback) {
+gulp.task('build-prod', function () {
     // Make minified file for production.
     webpackConfig.output.filename = 'FluxThis.min.js';
 

--- a/package.json
+++ b/package.json
@@ -22,29 +22,29 @@
   "author": "Jake Scott",
   "license": "Apache v2.0",
   "devDependencies": {
-    "babel": "4.7.12",
-    "babel-core": "4.7.12",
+    "babel": "5.0.7",
+    "babel-core": "5.0.7",
     "babel-eslint": "2.0.2",
-    "babel-loader": "4.1.0",
-    "body-parser": "1.12.0",
-    "express": "4.12.2",
+    "babel-loader": "5.0.0",
+    "body-parser": "1.12.2",
+    "express": "4.12.3",
     "gulp": "3.8.11",
     "gulp-clean": "0.3.1",
     "gulp-eslint": "0.7.0",
-    "gulp-express": "0.3.2",
+    "gulp-express": "0.3.5",
     "gulp-mocha-phantomjs": "0.5.3",
     "gulp-util": "3.0.4",
-    "gulp-webpack": "^1.3.0",
+    "gulp-webpack": "1.3.0",
     "mocha": "2.2.1",
     "mocha-phantomjs": "3.5.3",
     "phantomjs": "1.9.16",
-    "react": "0.12.2",
+    "react": "0.13.1",
     "run-sequence": "1.0.2",
     "should": "5.2.0",
     "webpack": "1.7.3"
   },
   "dependencies": {
-    "immutable": "3.6.4",
-    "invariant": "2.0.0"
+    "immutable": "^3.7.1",
+    "invariant": "^2.0.0"
   }
 }

--- a/src/ObjectOrientedStore.es6.js
+++ b/src/ObjectOrientedStore.es6.js
@@ -39,6 +39,8 @@ export default class ObjectOrientedStore extends Store {
 	 *	debugging
 	 */
 	constructor (options) {
+		super(options);
+
 		var store = this;
 		var changeEventPending = false;
 		var publicMethods;
@@ -46,32 +48,11 @@ export default class ObjectOrientedStore extends Store {
 		var privateMembers;
 		var bindActionsWasCalled = false;
 
-		invariant(
-			options,
-			'Cannot create ObjectOrientedStore without arguments'
-		);
-
-		invariant(
-			options.init,
-			'ObjectOrientedStore requires an `init` function'
-		);
-
-		invariant(
-			options.displayName,
-			'ObjectOrientedStore requires a `displayName` to assist you with debugging'
-		);
-
-		invariant(
-			options.public,
-			'ObjectOrientedStore requires `public` functions'
-		);
-
-		this.displayName = options.displayName;
 		this.dispatchToken = null;
+
 		this[CHANGE_LISTENERS] = new Set();
 
 		// This must be below displayName for displayName uniqueness checks
-		super();
 
 		publicMethods = Object.assign(this, options.public);
 

--- a/src/Store.es6.js
+++ b/src/Store.es6.js
@@ -24,9 +24,32 @@ var IN_PRODUCTION = process.env.NODE_ENV === 'production';
 var StoreDisplayNames = new Set();
 
 export default class Store {
-	constructor () {
+	constructor (options) {
 		var store = this;
 		var ViewDisplayNames = new Set();
+
+		invariant(
+			options,
+			'Cannot create FluxThis Stores without arguments'
+		);
+
+		invariant(
+			options.init,
+			'FluxThis Stores requires an `init` function'
+		);
+
+		invariant(
+			options.displayName,
+			'FluxThis Stores requires a `displayName` to assist you with debugging'
+		);
+
+		invariant(
+			options.public,
+			'ObjectOrientedStore requires `public` functions'
+		);
+
+		this.displayName = options.displayName;
+
 
 		// Ensure we have unique display names to assist with debugging.
 		if (!IN_PRODUCTION) {


### PR DESCRIPTION
Babel 5.0 has breaking changes that now impose restrictions defined in the ES6 specification. 

https://babeljs.io/blog/2015/03/31/5.0.0/#breaking-changes


I also upgrade dependencies & made our core dependencies a little more lax in which versions we use. 