### PR TITLE
Upgraded babel and reverted fix. Moved babel to core dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
   "author": "Jake Scott",
   "license": "Apache v2.0",
   "devDependencies": {
-    "babel": "5.0.7",
-    "babel-core": "5.0.7",
     "babel-eslint": "2.0.2",
     "babel-loader": "5.0.0",
     "body-parser": "1.12.2",
@@ -34,7 +32,7 @@
     "gulp-express": "0.3.5",
     "gulp-mocha-phantomjs": "0.5.3",
     "gulp-util": "3.0.4",
-    "gulp-webpack": "1.3.0",
+    "gulp-webpack": "^1.3.1",
     "mocha": "2.2.1",
     "mocha-phantomjs": "3.5.3",
     "phantomjs": "1.9.16",
@@ -44,6 +42,8 @@
     "webpack": "1.7.3"
   },
   "dependencies": {
+    "babel": "^5.0.8",
+    "babel-core": "^5.0.8",
     "immutable": "^3.7.1",
     "invariant": "^2.0.0"
   }

--- a/src/ImmutableStore.es6.js
+++ b/src/ImmutableStore.es6.js
@@ -61,12 +61,36 @@ class ImmutableStore extends ObjectOrientedStore {
 
 
 		if (options.init) {
-			parentOptions.init = initOverride(options);
+			parentOptions.init = function () {
+				options.init.call(this);
+
+				each(this, (key, member) => {
+					invariant(
+						ImmutableStore.checkImmutable(member),
+						'non-immutable, non-primitive `%s` was added to an ' +
+						'ImmutableStore during `init`',
+						key
+					);
+				});
+			};
 		}
 
 		if (options.public) {
 			each(options.public, (key, fn) => {
-				parentOptions.public[key] = publicOverride(key, fn);
+				parentOptions.public[key] = function () {
+					var result = fn.apply(this, arguments);
+
+					invariant(
+						ImmutableStore.checkImmutable(result),
+						'public method `%s` attempted to return a ' +
+						'non-immutable, non-primitive value. All accessors ' +
+						'must return immutable or primitive values to ' +
+						'prevent errors from mutation of objects',
+						key
+					);
+
+					return result;
+				};
 			});
 		}
 
@@ -78,52 +102,6 @@ class ImmutableStore extends ObjectOrientedStore {
 	}
 }
 
-/**
- * Returns a wrapper initialize method to impose Immutable
- * restrictions on the Store.
- *
- * @param {object} options
- * @returns {Function}
- */
-function initOverride(options) {
-	return function () {
-		options.init.call(this);
-
-		each(this, (key, member) => {
-			invariant(
-				ImmutableStore.checkImmutable(member),
-				'non-immutable, non-primitive `%s` was added to an ' +
-				'ImmutableStore during `init`',
-				key
-			);
-		});
-	};
-}
-
-/**
- * Returns a wrapper public method to impose Immutable
- * restrictions on the Store.
- *
- * @param {string} key
- * @param {Function} fn
- * @returns {Function}
- */
-function publicOverride(key, fn) {
-	return function () {
-		var result = fn.apply(this, arguments);
-
-		invariant(
-			ImmutableStore.checkImmutable(result),
-			'public method `%s` attempted to return a ' +
-			'non-immutable, non-primitive value. All accessors ' +
-			'must return immutable or primitive values to ' +
-			'prevent errors from mutation of objects',
-			key
-		);
-
-		return result;
-	};
-}
 ImmutableStore.Immutable = Immutable;
 
 export default ImmutableStore;


### PR DESCRIPTION
I reverted the ugly closure fix for babel back to how it was.

I also moved babel & babel core to be core dependencies since we use them when you require fluxthis's built file. 