### PR TITLE
constant collection tostrings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxthis",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "AddThis Flux Framework",
   "main": "build/FluxThis.js",
   "directories": {

--- a/src/ConstantCollection.es6.js
+++ b/src/ConstantCollection.es6.js
@@ -50,6 +50,6 @@ class Constant {
 		this.collection = collection;
 	}
 	toString() {
-		return `${this.collection.id}_${this.name}`;
+		return `${this.name}_#${this.collection.id}`;
 	}
 }

--- a/src/ConstantCollection.es6.js
+++ b/src/ConstantCollection.es6.js
@@ -26,8 +26,9 @@ const invariant = require('invariant');
  */
 export default class ConstantCollection {
 	constructor (...names) {
-		names.forEach((name) => {
 
+		this.id = Math.random().toString(36).substring(2);
+		names.forEach((name) => {
 			invariant(
 				this[name] === undefined,
 				'The constant `%s` already exists in this collection',
@@ -47,5 +48,8 @@ class Constant {
 	constructor (name, collection) {
 		this.name = name;
 		this.collection = collection;
+	}
+	toString() {
+		return `${this.collection.id}_${this.name}`;
 	}
 }

--- a/test/src/constant-collection-tests.js
+++ b/test/src/constant-collection-tests.js
@@ -40,4 +40,9 @@ describe('Constant Collections', function () {
             Should(Object.isFrozen(CC)).equal(true);
         }
     });
+
+    it('should provide constants with good toString methods', function () {
+        var CC = new ConstantCollection('HI');
+        CC.HI.toString().should.equal(CC.id + '_HI');
+    });
 });

--- a/test/src/constant-collection-tests.js
+++ b/test/src/constant-collection-tests.js
@@ -43,13 +43,12 @@ describe('Constant Collections', function () {
 
     it('should provide constants with good toString methods', function () {
         var CC = new ConstantCollection('HI');
-        CC.HI.toString().should.equal(CC.id + '_HI');
+        CC.HI.toString().should.equal('HI_#' + CC.id);
     });
 
-    it('should provide constants which can be used as keys in objects', function () {
-        var CC = new ConstantCollection('HI');
-        var obj = {};
-        obj[CC.HI] = 'test';
-        Should(obj[CC.id + '_HI']).equal('test');
-    });
+    it('should provide constants with unique strings when they share keys', function () {
+        var CC1 = new ConstantCollection('HI');
+        var CC2 = new ConstantCollection('HI');
+        CC1.HI.toString().should.not.equal(CC2.HI.toString());
+    })
 });

--- a/test/src/constant-collection-tests.js
+++ b/test/src/constant-collection-tests.js
@@ -45,4 +45,11 @@ describe('Constant Collections', function () {
         var CC = new ConstantCollection('HI');
         CC.HI.toString().should.equal(CC.id + '_HI');
     });
+
+    it('should provide constants which can be used as keys in objects', function () {
+        var CC = new ConstantCollection('HI');
+        var obj = {};
+        obj[CC.HI] = 'test';
+        Should(obj[CC.id + '_HI']).equal('test');
+    });
 });


### PR DESCRIPTION
allow constant collections to be used in normal objects (because they have a toString method now)