### PR TITLE
Payload stringify

### DIFF
--- a/src/ConstantCollection.es6.js
+++ b/src/ConstantCollection.es6.js
@@ -38,9 +38,7 @@ export default class ConstantCollection {
 			this[name] = new Constant(name, this);
 		});
 
-		if (Object.freeze instanceof Function) {
-			Object.freeze(this);
-		}
+		Object.freeze(this);
 	}
 }
 

--- a/src/Dispatcher.es6.js
+++ b/src/Dispatcher.es6.js
@@ -180,16 +180,16 @@ export default class Dispatcher {
 		// to see if the object has changed. The check is not very efficient,
 		// but will at least throw errors when things change, like freeze would
 		// do for us in strict mode
-		let serializedAction;
+		let serializedPayload;
 
 		if (process.env.NODE_ENV !== 'production') {
 			try {
-				serializedAction = JSON.stringify(action);
+				serializedPayload = JSON.stringify(action.payload);
 			}
 			catch(err) {
 				invariant(
 					!err,
-					'Actions must be simple objects, and must be stringifyable.'
+					'Payloads must be simple objects, and must be stringifyable.'
 				);
 			}
 		}
@@ -216,7 +216,7 @@ export default class Dispatcher {
 			//check for mutations
 			if (process.env.NODE_ENV !== 'production') {
 				invariant(
-					JSON.stringify(action) === serializedAction,
+					JSON.stringify(action.payload) === serializedPayload,
 					`An action dispatched by the FluxThis dispatcher was
 					mutated. This is bad. Please check the handlers for
 					%s %s.`,

--- a/test/src/constant-collection-tests.js
+++ b/test/src/constant-collection-tests.js
@@ -50,5 +50,5 @@ describe('Constant Collections', function () {
         var CC1 = new ConstantCollection('HI');
         var CC2 = new ConstantCollection('HI');
         CC1.HI.toString().should.not.equal(CC2.HI.toString());
-    })
+    });
 });

--- a/test/src/integration-tests.js
+++ b/test/src/integration-tests.js
@@ -13,6 +13,8 @@
  */
 
 var ActionCreator = require('../../src/ActionCreator.es6');
+var ConstantCollection = require('../../src/ConstantCollection.es6')
+var Dispatcher = require('../../src/Dispatcher.es6');
 var Store = require('../../src/ImmutableStore.es6');
 
 describe('Integration', function () {
@@ -210,6 +212,22 @@ describe('Integration', function () {
 			});
 			ac.addThing('hi');
 			str.should.equal('abc');
+		});
+	});
+
+	describe('A dispatcher', function () {
+		describe('when dispatching an event with ConstantCollection types', function () {
+			it('should not throw', function () {
+		        var CC = new ConstantCollection('HI');
+		        var dispatcher = new Dispatcher();
+
+		        (function () {
+		        	dispatcher.dispatch({
+		        		type: CC.HI,
+		        		payload: 'derp'
+		        	});
+		        }).should.not.throw();
+			});
 		});
 	});
 });


### PR DESCRIPTION
constant collections were breaking a stringify used to check for immutability in actions.  This is somewhat of a work-around, and doesnt address the larger issue, but should be OK for now.