### PR TITLE
Remove babel polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel-eslint": "^3.0.1",
     "babel-loader": "5.0.0",
+    "babel-runtime": "^5.4.5",
     "body-parser": "^1.12.3",
     "express": "4.12.3",
     "gulp": "3.8.11",

--- a/src/FluxThis.es6.js
+++ b/src/FluxThis.es6.js
@@ -14,8 +14,6 @@
 
 'use strict';
 
-require('babel/polyfill');
-
 export default {
 	ConstantCollection: require('./ConstantCollection.es6'),
 	ImmutableStore: require('./ImmutableStore.es6'),

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
     },
     module: {
         loaders: [{
-             test: /\.es6\.js$/, exclude: /node_modules/, loader: 'babel-loader'
+             test: /\.es6\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional[]=runtime'
         }]
     }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
     },
     module: {
         loaders: [{
-             test: /\.es6\.js$/, exclude: /node_modules/, loader: 'babel-loader'
+             test: /\.es6\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional[]=runtime'
         }]
     }
 };


### PR DESCRIPTION
The babel polyfill should be defined once at the main entry point to an application, and a runtime error will occur if  it is required multiple times.

```
Uncaught Error: only one instance of babel/polyfill is allowed
```

This isn't suitable for third party libraries, which should be directly compiled to rely on babel-runtime.

This PR therefore removes the babel polyfill, and instead requires on the babel runtime compile option. From the babel runtime [docs](http://babeljs.io/docs/usage/runtime/)

```
[...] you can use built-ins such as Promise, Set, Symbol etc as well use as all the Babel features that require a polyfill seamlessly, without global pollution, making it extremely suitable for libraries.
```

Relevant issues - #29, #60