### PR TITLE
Prevents errors from being thrown when symbols are used as action typ…

### DIFF
--- a/src/ObjectOrientedStore.es6.js
+++ b/src/ObjectOrientedStore.es6.js
@@ -94,8 +94,10 @@ export default class ObjectOrientedStore extends Store {
 
 						invariant(
 							!actions.has(constant),
-							`${this} - The action ${constant} has already ` +
-							'been defined in this store.'
+							`%s - The action %s has already ` +
+							'been defined in this store.',
+							this.toString(),
+							constant.toString()
 						);
 
 						actions.set(constant, handler);

--- a/test/src/object-oriented-store-tests.js
+++ b/test/src/object-oriented-store-tests.js
@@ -101,6 +101,23 @@ describe('ObjectOrientedStore', function () {
 		}).should.throw();
 	});
 
+	it('should not throw an error when a symbol is used for an action type', function () {
+		(function () {
+			new Store({
+				displayName: 'oo-symbol-action',
+				init: function(){
+					this.bindActions(
+						Symbol('hi'), this.test
+					);
+				},
+				public:{},
+				private:{
+					test: function() {}
+				}
+			});
+		}).should.not.throw();
+	});
+
 	describe('during init', function () {
 		var config;
 		beforeEach(function () {

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -13,6 +13,7 @@
  */
 
 // THIS MUST BE FIRST. It loads the babel/polyfill
+require('babel/polyfill');
 require('./require-test');
 
 window.FluxThis = {


### PR DESCRIPTION
…es due to their concatenation to strings when checking for duplicate action types