### PR TITLE
Js/minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "babel": "^5.0.8",
     "babel-core": "^5.0.8",
-    "immutable": "^3.7.1",
+    "immutable": "3.7.3",
     "invariant": "^2.0.0",
     "path-to-regexp": "^1.2.0",
     "qs": "^3.1.0",

--- a/src/ActionCreator.es6.js
+++ b/src/ActionCreator.es6.js
@@ -142,8 +142,10 @@ class ActionCreator {
 		// Now lets make sure we haven't already registered aciton type
 		invariant(
 			!ActionTypes.has(type),
-			`${this} - already has an action with type ${type} already ` +
-			'registered.'
+			`%s - already has an action with type %s already ` +
+			'registered.',
+			this.toString(),
+			type.toString()
 		);
 
 		// Add the new type to the Set so we can keep checking for uniqueness.

--- a/src/ObjectOrientedStore.es6.js
+++ b/src/ObjectOrientedStore.es6.js
@@ -78,8 +78,8 @@ export default class ObjectOrientedStore extends Store {
 							constant !== undefined && constant !== null,
 							'An unrecognizable action type or source, `%s`, ' +
 							'was passed to the `bindActions` method of `%s`',
-							constant,
-							this
+							constant.toString(),
+							this.toString()
 						);
 
 						invariant(
@@ -88,8 +88,8 @@ export default class ObjectOrientedStore extends Store {
 							'passed to the `bindActions` method of `%s` to ' +
 							'handle `%s`',
 							handler,
-							this,
-							constant
+							this.toString(),
+							constant.toString()
 						);
 
 						invariant(

--- a/src/Store.es6.js
+++ b/src/Store.es6.js
@@ -27,7 +27,6 @@ const CHANGE_LISTENERS = Symbol();
 export default class Store {
 	constructor(options) {
 		const store = this;
-		const ViewDisplayNames = new Set();
 
 		invariant(
 			options,
@@ -79,16 +78,6 @@ export default class Store {
 				);
 
 				invariant(
-					!ViewDisplayNames.has(displayName),
-					`Error: ${store.toString()} already has a ` +
-					'controller view registered with the display name ' +
-					`of ${displayName}. Please make sure ` +
-					'display names are unique.'
-				);
-
-				ViewDisplayNames.add(displayName);
-
-				invariant(
 					this.getStateFromStores instanceof Function,
 					'`%s` must define `getStateFromStores` in order to use ' +
 					'the FluxThis mixin.',
@@ -114,7 +103,6 @@ export default class Store {
 			 */
 			componentWillUnmount() {
 				renderedComponentSet.delete(this);
-				ViewDisplayNames.delete(this.constructor.displayName);
 				store.removeChangeListener(this.__fluxChangeListener);
 			},
 


### PR DESCRIPTION
Removes an invariant which triggers on duplicate displaynames.  We actually don't require unique display names for anything.

I am running into an issue where FT is throwing this invariant when I have multiple controller views which are wrapped in a parent component:
```
<Modal>
  <ControllerVIew1/>
</Modal>
<Modal>
  <ControllerVIew2/>
</Modal>
```
`Invariant Violation: Error: [ImmutableStore] already has a controller view registered with the display name of Modal`