### PR TITLE
regex contains test instead of equality

### DIFF
--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -94,7 +94,7 @@ export default function implore(request) {
 				response.status = xhr.status;
 				response.type = xhr.getResponseHeader('Content-Type');
 
-				if (response.type === 'application/json') {
+				if (/application\/json/.test(response.type)) {
 					try {
 						response.body = JSON.parse(responseText);
 					} catch (err) {


### PR DESCRIPTION
xhr response Content-Type header may contain other values from the
server.  ex: "application/json; charset=utf-8"