### PR TITLE
Added ability to abort XHR requests from api action creator

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -33,6 +33,8 @@ It's x.y.z where:
  * z: strive for bug fix only
 
 ### Changes
+ * v2.5.0 (TBD)
+    - [#106](https://github.com/addthis/fluxthis/pull/106) - Added abort support to APIActionCreator
  * v2.4.0 (12/1/15)
     - [#100](https://github.com/addthis/fluxthis/issues/100) - support content type json w/ charset
  * v2.3.1 (11/2/15)

--- a/lib/each.es6.js
+++ b/lib/each.es6.js
@@ -18,18 +18,13 @@
  * Iterates over `collection`, passing each key and value to `callback`. If
  * `callback` returns false, the loop will be broken early.
  */
-module.exports = function each(collection, callback, context) {
-    var key;
-    var keepGoing;
-
+export default function (collection, callback, context) {
     context = context || this;
 
-    for (key in collection) {
-        if (collection.hasOwnProperty(key)) {
-            keepGoing = callback.call(context, key, collection[key], collection);
-            if (keepGoing === false) {
-                break;
-            }
+    for (let key of Object.keys(collection)) {
+        let keepGoing = callback.call(context, key, collection[key], collection);
+        if (keepGoing === false) {
+            break;
         }
     }
-};
+}

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -16,6 +16,7 @@
 
 const invariant = require('invariant');
 const deprecated = require('./deprecated.es6');
+const Request = require('./request.es6');
 
 /**
  * @typedef {object} request
@@ -27,7 +28,7 @@ const deprecated = require('./deprecated.es6');
  */
 
 /**
- * @typedef {object} reponse
+ * @typedef {object} response
  * @property {Error} error - an error which occured during req or res
  * @property {object} body - content received from server (parsed)
  * @property {object} headers - set additional request headers
@@ -37,124 +38,124 @@ const deprecated = require('./deprecated.es6');
 /**
  * XHR wrapper for same-domain requests with Content-Type: application/json
  *
- * @param {request} request
- * @return {Promise}
+ * @param {Object} request
+ * @param {Function} callback function
+ * @return {Object} request object that is cancelable
  */
-export default function implore(request) {
-	return new Promise(resolve => {
-		const response = {
-			error: null
-		};
+export default function implore(request, callback) {
+	const response = {
+		error: null
+	};
 
-		invariant(
+	const {withCredentials=false, headers={}} = request;
+	const xhr = new XMLHttpRequest();
+
+	invariant(
+		request,
+		'implore requires a `request` argument'
+	);
+
+	invariant(
+		typeof request.route === 'string',
+		'implore requires parameter `route` to be a string'
+	);
+
+	invariant(
+		typeof request.method === 'string',
+		'implore requires parameter `method` to be a string'
+	);
+
+	invariant(
+		typeof withCredentials === 'boolean',
+		'implore requires parameter `withCredentials` to be a boolean'
+	);
+
+	invariant(
+		typeof headers === 'object',
+		'implore requires parameter `headers` to be an object'
+	);
+
+	xhr.open(request.method, getURLFromRequest(request));
+	xhr.withCredentials = request.withCredentials;
+
+	switch (request.method) {
+		case 'POST':
+		case 'PUT':
+		case 'PATCH':
+			xhr.setRequestHeader('Content-Type', 'application/json');
+			break;
+	}
+
+	if (request.contentType) {
+		deprecated(true, 'contentType in createRequest', 'requestHeaders');
+		xhr.setRequestHeader('Content-Type', request.contentType);
+	}
+
+	Object.keys(headers).forEach((header) => {
+		xhr.setRequestHeader(header, headers[header]);
+	});
+
+	xhr.onabort = function onabort() {
+		callback({
 			request,
-			'implore requires a `request` argument'
-		);
-
-		invariant(
-			typeof request.route === 'string',
-			'implore requires parameter `route` to be a string'
-		);
-
-		invariant(
-			typeof request.method === 'string',
-			'implore requires parameter `method` to be a string'
-		);
-
-		const {requestHeaders={}} = request;
-		invariant(
-			typeof requestHeaders === 'object',
-			'implore requires parameter `requestHeaders` to be an object'
-		);
-
-		const {withCredentials=false} = request;
-		invariant(
-			typeof withCredentials === 'boolean',
-			'implore requires parameter `withCredentials` to be a boolean'
-		);
-
-		const xhr = new XMLHttpRequest();
-
-		xhr.open(request.method, getURLFromRequest(request));
-		xhr.withCredentials = request.withCredentials;
-
-		switch (request.method) {
-			case 'POST':
-			case 'PUT':
-			case 'PATCH':
-				xhr.setRequestHeader('Content-Type', 'application/json');
-				break;
-		}
-
-		if (request.contentType) {
-			deprecated(true, 'contentType in createRequest', 'requestHeaders');
-			xhr.setRequestHeader('Content-Type', request.contentType);
-		}
-
-		Object.keys(requestHeaders).forEach((headerKey) => {
-			xhr.setRequestHeader(headerKey, requestHeaders[headerKey]);
-		});
-
-		if (request.headers) {
-			invariant(
-				typeof request.headers === 'object',
-				'implore requires parameter `headers` to be an object'
-			);
-
-			Object.keys(request.headers).forEach((header) => {
-				xhr.setRequestHeader(header, request.headers[header]);
-			});
-		}
-
-		xhr.onreadystatechange = function onreadystatechange() {
-			let responseText;
-
-			if (xhr.readyState === 4) {
-				responseText = xhr.responseText;
-				response.status = xhr.status;
-				response.type = xhr.getResponseHeader('Content-Type');
-
-				if (/application\/json/.test(response.type)) {
-					try {
-						response.body = JSON.parse(responseText);
-					} catch (err) {
-						err.message = err.message + ' while parsing `' +
-							responseText + '`';
-						response.body = {};
-						response.status = xhr.status || 0;
-						response.error = err;
-					}
-				}
-				else {
-					response.body = responseText;
-				}
-
-				return resolve({
-					request,
-					response
-				});
+			response: {
+				fluxthisAborted: true
 			}
-		};
+		});
+	};
 
-		try {
-			if (request.body) {
-				xhr.send(JSON.stringify(request.body));
+	xhr.onreadystatechange = function onreadystatechange() {
+		let responseText;
+
+		if (xhr.readyState === 4 && xhr.status !== 0) {
+			responseText = xhr.responseText;
+			response.status = xhr.status;
+			response.type = xhr.getResponseHeader('Content-Type');
+
+			if (/application\/json/.test(response.type)) {
+				try {
+					response.body = JSON.parse(responseText);
+				} catch (err) {
+					err.message = err.message + ' while parsing `' +
+						responseText + '`';
+					response.body = {};
+					response.status = xhr.status || 0;
+					response.error = err;
+				}
 			}
 			else {
-				xhr.send();
+				response.body = responseText;
 			}
-		}
-		catch (err) {
-			response.body = {};
-			response.status = 0;
-			response.error = err;
 
-			return resolve({
+			callback({
 				request,
 				response
 			});
 		}
-	});
+	};
+
+	try {
+		if (request.body) {
+			xhr.send(JSON.stringify(request.body));
+		}
+		else {
+			xhr.send();
+		}
+	}
+	catch (err) {
+		response.body = {};
+		response.status = 0;
+		response.error = err;
+
+		callback({
+			request,
+			response
+		});
+
+		return null;
+	}
+
+	return new Request(xhr);
 }
 
 implore.get = function get(options) {

--- a/lib/request.es6.js
+++ b/lib/request.es6.js
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const XHR = Symbol();
+
+export default class {
+	/**
+	 * Creates a new Request object returned by api action creator
+	 *
+	 * @param {XMLHttpRequest} xhr
+	 */
+	constructor(xhr) {
+		this[XHR] = xhr;
+	}
+
+	/**
+	 * Stops the request by calling abort if any only if the request
+	 * is not already done.
+	 *
+	 * @return {boolean} true if aborted, false if already done
+	 */
+	abort() {
+		const xhr = this[XHR];
+
+		// if the request has already been aborted then return true.
+		if (xhr.readyState === 0) {
+			return true;
+		}
+
+		// if the request is done then we can't abort it.
+		if (xhr.readyState === 4) {
+			return false;
+		}
+
+		this[XHR].abort();
+
+		return true;
+	}
+
+	/**
+	 * Returns true if the request has been aborted or the request is finished.
+	 *
+	 * @return {boolean}
+	 */
+	isDone() {
+		return this[XHR].readyState === 4 || this[XHR].readyState === 0;
+	}
+}

--- a/src/ActionCreator.es6.js
+++ b/src/ActionCreator.es6.js
@@ -16,7 +16,7 @@
 
 const dispatcher = require('./dispatcherInstance.es6');
 const debug = require('./debug.es6');
-const each = require('../lib/each');
+const each = require('../lib/each.es6');
 const PropTypes = require('react/lib/ReactPropTypes');
 const deprecated = require('../lib/deprecated.es6');
 const invariant = require('invariant');

--- a/src/ImmutableStore.es6.js
+++ b/src/ImmutableStore.es6.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const each = require('../lib/each');
+const each = require('../lib/each.es6');
 const invariant = require('invariant');
 const Immutable = require('immutable');
 const ObjectOrientedStore = require('./ObjectOrientedStore.es6');

--- a/src/ObjectOrientedStore.es6.js
+++ b/src/ObjectOrientedStore.es6.js
@@ -17,7 +17,7 @@
 const dispatcher = require('./dispatcherInstance.es6');
 const Store = require('./Store.es6');
 const debug = require('./debug.es6');
-const each = require('../lib/each');
+const each = require('../lib/each.es6');
 const invariant = require('invariant');
 const testUtils = require('./StoreTestUtils.es6');
 

--- a/src/StoreTestUtils.es6.js
+++ b/src/StoreTestUtils.es6.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dispatcher = require('./dispatcherInstance.es6');
-const each = require('../lib/each');
+const each = require('../lib/each.es6');
 
 /**
  * This function provides all the test utilities

--- a/src/debug.es6.js
+++ b/src/debug.es6.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const dispatcher = require('./dispatcherInstance.es6');
-const each = require('../lib/each');
+const each = require('../lib/each.es6');
 const RouterConstants = require('./router/RouterConstants.es6');
 
 const IN_PRODUCTION = process.env.NODE_ENV === 'production';

--- a/test/server.js
+++ b/test/server.js
@@ -43,6 +43,22 @@ app.post('/dog', function (req, res) {
     res.end(message);
 });
 
+app.post('/long-time', function (req, res) {
+    setTimeout(function() {
+        var message = JSON.stringify({
+            cat: 'purr'
+        });
+
+        res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Content-Size': message.length
+        });
+
+        res.end(message);
+    }, 300);
+
+});
+
 app.post('/mirror/:param1/:param2', bodyParser.json(), mirror);
 app.post('/mirror', bodyParser.json(), mirror);
 app.use(express.static('./'));

--- a/test/src/integration-tests.js
+++ b/test/src/integration-tests.js
@@ -58,7 +58,7 @@ describe('Integration', function () {
 			respondToSource: {
 				type: '__' + Math.random()
 			}
-		})
+		});
 
 		store = new Store({
 			displayName: String(Math.random()),

--- a/test/src/request-tests.js
+++ b/test/src/request-tests.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var Request = require('../../lib/request.es6.js');
+
+describe('Request Tests', function () {
+
+	it('should create a request object with one symbol attribute', function () {
+		var request = new Request({});
+		Object.getOwnPropertySymbols(request).length.should.eql(1);
+	});
+
+	it('should have an abort method and return true', function (done) {
+		var request = new Request({
+			abort: function() {
+				done();
+			}
+		}, {}, function() {});
+
+		request.abort().should.eql(true);
+	});
+
+	it('should return false since request is done', function () {
+		var request = new Request({
+			readyState: 4
+		}, {}, function() {});
+
+		request.abort().should.eql(false);
+	});
+});

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -31,3 +31,4 @@ require('./constant-collection-tests');
 require('./store-tests');
 require('./router-store-spec.es6.js');
 require('./route-spec.es6.js');
+require('./request-tests');


### PR DESCRIPTION
* moved each.js to es6 compatible. 
* Removed promise from implore since it caused invariants / exceptions to be displayed in a horrible wrapped way.
* Return new request object that has an abort method to be handled by application. 


# Example

```
onClick() {
  const request = this.state.request;
  // If the previous request is still executing then cancel
  if (request && !request.isDone()) {
      request.abort();
  }
  
  request = actionCreator.doSomething();
  this.setState({request});
}
```