### PR TITLE
[#115] No longer replace response body if error during json parse

### DIFF
--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -105,26 +105,18 @@ export default function implore(request, callback) {
 	};
 
 	xhr.onreadystatechange = function onreadystatechange() {
-		let responseText;
-
 		if (xhr.readyState === 4 && xhr.status !== 0) {
-			responseText = xhr.responseText;
+			response.body = xhr.responseText;
 			response.status = xhr.status;
 			response.type = xhr.getResponseHeader('Content-Type');
 
 			if (/application\/json/.test(response.type)) {
 				try {
-					response.body = JSON.parse(responseText);
+					response.body = JSON.parse(response.body);
 				} catch (err) {
-					err.message = err.message + ' while parsing `' +
-						responseText + '`';
-					response.body = {};
 					response.status = xhr.status || 0;
 					response.error = err;
 				}
-			}
-			else {
-				response.body = responseText;
 			}
 
 			callback({

--- a/test/src/api-action-creator-tests.js
+++ b/test/src/api-action-creator-tests.js
@@ -96,7 +96,7 @@ describe('APIActionCreators', function () {
         aac.doThing();
     });
 
-    it('should the body as JSON with a mimetype of "application/json"', function (done) {
+    it('should parse the body as JSON with a mimetype of "application/json"', function (done) {
         var aac = new APIActionCreator({
             displayName: 'api' + Math.random(),
             doThing: {
@@ -122,7 +122,7 @@ describe('APIActionCreators', function () {
         aac.doThing();
     });
 
-    it('should the body as JSON with a mimetype of "application/json; charset=utf-8"', function (done) {
+    it('should parse the body as JSON with a mimetype of "application/json; charset=utf-8"', function (done) {
         var aac = new APIActionCreator({
             displayName: 'api' + Math.random(),
             doThing: {
@@ -176,7 +176,9 @@ describe('APIActionCreators', function () {
                 handleSuccess: function () {
                     done(new Error('handleSuccess was called'));
                 },
-                handleFailure: function () {
+                handleFailure: function (req, res) {
+                    res.body.should.equal('hello world');
+                    res.error.should.be.instanceOf(Error);
                     done();
                 }
             }


### PR DESCRIPTION
This PR builds upon the work of #113 / #114 by providing access to the original response body if a JSON error occurrs during parsing