### PR TITLE
Add arguments to original API call (not the XHR request) for visibility in the callback.

### DIFF
--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -158,7 +158,8 @@ export default class APIActionCreator extends ActionCreator {
 
 			request = Object.assign({
 				method,
-				route
+				route,
+                                args
 			}, request);
 
 			this.validatePayload(name, request, payloadType);

--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -159,7 +159,7 @@ export default class APIActionCreator extends ActionCreator {
 			request = Object.assign({
 				method,
 				route,
-                                args
+				args
 			}, request);
 
 			this.validatePayload(name, request, payloadType);


### PR DESCRIPTION
This comes in handy if you need to chain API calls with different arguments