### PR TITLE
Fix for #142 (allows named parameters with file extensions)

### DIFF
--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -194,7 +194,6 @@ implore.delete = function httpDelete(options) {
 function getURLFromRequest(request) {
 	const queryString = makeQueryString(request.query || {});
 	let formatted = request.route;
-	let name;
 	let value;
 	let regexp;
 

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -198,13 +198,13 @@ function getURLFromRequest(request) {
 	let value;
 	let regexp;
 
-	for (name in request.params) {
-		if (request.params.hasOwnProperty(name)) {
-			value = request.params[name];
-			regexp = new RegExp(':' + name + '(?=(\\\/|$))');
-			formatted = formatted.replace(regexp, value);
-		}
-	}
+	// Replace route params with their values. If the route param is specified
+	// with an extension (e.g., ':id.json'), keep the extension.
+	Object.keys(request.params || {}).forEach((name) => {
+		value = request.params[name];
+		regexp = new RegExp(':' + name + '(?=(?:\\.|\\/|$|\\?))');
+		formatted = formatted.replace(regexp, value);
+	});
 
 	return formatted + (queryString ? '?' + queryString : '');
 }

--- a/test/server.js
+++ b/test/server.js
@@ -71,6 +71,7 @@ app.get('/invalid-json', function (req, res) {
 });
 
 app.post('/mirror/:param1/:param2', bodyParser.json(), mirror);
+app.post('/mirror/:param1', bodyParser.json(), mirror);
 app.post('/mirror', bodyParser.json(), mirror);
 app.use(express.static('./'));
 
@@ -80,7 +81,8 @@ function mirror (req, res) {
     var message = JSON.stringify({
         query: req.query,
         params: req.params,
-        body: req.body
+        body: req.body,
+        path: req.path
     });
 
     res.writeHead(200, {

--- a/test/src/api-action-creator-tests.js
+++ b/test/src/api-action-creator-tests.js
@@ -249,6 +249,39 @@ describe('APIActionCreators', function () {
         aac.doThing('hi', 'mom');
     });
 
+    it('should allow for named parameters with file extensions', function (done) {
+        var userId = Math.random();
+        var aac = new APIActionCreator({
+            displayName: 'api' + Math.random(),
+            doThing: {
+                route: '/mirror/:userId.json',
+                method: 'POST',
+                createRequest: function (userId) {
+                    return {
+                        params: {
+                            userId: userId
+                        }
+                    };
+                },
+                handleFailure: function (req, res) {
+                    done(req.error || res.error || new Error('Request failed'));
+                },
+                handleSuccess: function (req, res) {
+                    try {
+                        req.params.userId.should.eql(userId);
+                        res.body.path.should.eql('/mirror/' + userId + '.json');
+                        done();
+                    }
+                    catch (err) {
+                        done(err);
+                    }
+                }
+            }
+        });
+        
+        aac.doThing(userId);
+    });
+
 	it('should throw an error for passing args without create request', function () {
 		(function () {
 			var aac = new APIActionCreator({


### PR DESCRIPTION
I ran a few small manual tests in addition to writing an automated test for this, and all seems to indicate that this works as expected. Feel free to give it a spin with more "real life" cases before merging the PR if you'd like; I haven't had a chance to actually do that yet, but will do it later on.