### PR TITLE
Move babel to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "react": ">=0.13.2"
   },
   "devDependencies": {
+    "babel": "^5.0.8",
+    "babel-core": "^5.0.8",
     "babel-eslint": "^4.1.7",
     "babel-loader": "^5.1.3",
     "babel-runtime": "^5.4.5",
@@ -58,8 +60,6 @@
     "webpack": "^1.8.9"
   },
   "dependencies": {
-    "babel": "^5.0.8",
-    "babel-core": "^5.0.8",
     "immutable": "^3.7.1",
     "invariant": "^2.0.0",
     "path-to-regexp": "^1.2.0",


### PR DESCRIPTION
`babel` and `babel-core` are dev dependencies as they're used in the build process.

#### Why does it matter?

Node Security Platform have put up an advisory regarding one of babels v5 dependencies - https://nodesecurity.io/advisories/118
As a dependency of `fluxthis`, applications which use the `nsp` module will receive false positive warnings that a module on their dependency tree has an issue. Moving these to dev dependencies should remove this warning.

__Update:__ Confirmed that `nsp` warnings no longer show when using this branch.