### PR TITLE
Log which actions dispatched during a dispatch

### DIFF
--- a/src/Dispatcher.es6.js
+++ b/src/Dispatcher.es6.js
@@ -189,7 +189,7 @@ export default class Dispatcher {
 			'in the middle of a dispatch. Was dispatching action ' +
 			JSON.stringify(this[PENDING_ACTION]) +
 			' when this action was called: ' +
-			JSON.stringify(action)
+			'type: ' + type + ' source: ' + source
 		);
 
 		invariant(

--- a/src/Dispatcher.es6.js
+++ b/src/Dispatcher.es6.js
@@ -186,7 +186,10 @@ export default class Dispatcher {
 		invariant(
 			!this[IS_DISPATCHING],
 			'Dispatch.dispatch(...): Cannot dispatch ' +
-			'in the middle of a dispatch.'
+			'in the middle of a dispatch. Was dispatching action ' +
+			JSON.stringify(this[PENDING_ACTION]) +
+			' when this action was called: ' +
+			JSON.stringify(action)
 		);
 
 		invariant(


### PR DESCRIPTION
The message before was:
```
Cannot dispatch in the middle of a dispatch in the middle of a dispatch
```
Which isn't too informative

It now says:
```es6
`Cannot dispatch in the middle of a dispatch in the middle of a dispatch. Was dispatching action ${JSON.stringify(pendingAction)} when this action was called: ${JSON.stringify(nextAction)}`
```
