### PR TITLE
Expose response headers to APIActionCreators

### DIFF
--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -121,7 +121,16 @@ export default function implore(request, callback) {
 			response.body = xhr.responseText;
 			response.status = xhr.status;
 			response.type = xhr.getResponseHeader('Content-Type');
-			response.headers = xhr.getAllResponseHeaders();
+			const rawHeaders = xhr.getAllResponseHeaders();
+			// Just in case some headers don't get processed properly
+			response.rawHeaders = rawHeaders;
+			// Processed headers as a hash for easier use
+			const responseHeaders = rawHeaders.split("\n");
+			response.headers = {};
+			for (let header of responseHeaders) {
+				const parts = header.split(': ');
+				response.headers[parts[0]] = parts[1];
+			}
 
 			if (/application\/json/.test(response.type)) {
 				if (response.body && response.status !== 204) {

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -121,6 +121,7 @@ export default function implore(request, callback) {
 			response.body = xhr.responseText;
 			response.status = xhr.status;
 			response.type = xhr.getResponseHeader('Content-Type');
+			response.headers = xhr.getAllResponseHeaders();
 
 			if (/application\/json/.test(response.type)) {
 				if (response.body && response.status !== 204) {

--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -121,15 +121,16 @@ export default function implore(request, callback) {
 			response.body = xhr.responseText;
 			response.status = xhr.status;
 			response.type = xhr.getResponseHeader('Content-Type');
-			const rawHeaders = xhr.getAllResponseHeaders();
-			// Just in case some headers don't get processed properly
-			response.rawHeaders = rawHeaders;
-			// Processed headers as a hash for easier use
-			const responseHeaders = rawHeaders.split("\n");
+
+			// Expose headers in raw form (string) and in a more convenient form (hash)
+			response.rawHeaders = xhr.getAllResponseHeaders();
+			const responseHeaders = response.rawHeaders.split('\n');
 			response.headers = {};
 			for (let header of responseHeaders) {
-				const parts = header.split(': ');
-				response.headers[parts[0]] = parts[1];
+				const parts = header.split(':');
+				if (parts.length === 2) {
+					response.headers[parts[0].trim()] = parts[1].trim();
+				}
 			}
 
 			if (/application\/json/.test(response.type)) {

--- a/test/src/api-action-creator-tests.js
+++ b/test/src/api-action-creator-tests.js
@@ -70,6 +70,33 @@ describe('APIActionCreators', function () {
         aac.doThing();
     });
 
+    it('should expose headers in string and hash form', function (done) {
+        var aac = new APIActionCreator({
+            displayName: 'api' + Math.random(),
+            doThing: {
+                route: '/mirror',
+                method: 'POST',
+                createRequest: function () {
+                    return {
+                        query: {
+                            contentType: 'application/json'
+                        }
+                    };
+                },
+                handleSuccess: function (req, res) {
+                    res.rawHeaders.should.be.type('string');
+                    res.headers.should.be.type('object');
+                    done();
+                },
+                handleFailure: function (req, res) {
+                    done(req.error || res.error || new Error('Request failed'));
+                }
+            }
+        });
+
+        aac.doThing();
+    });
+
     it('should not parse the body as JSON with a mimetype of "text/plain"', function (done) {
         var aac = new APIActionCreator({
             displayName: 'api' + Math.random(),


### PR DESCRIPTION
Should not need to fallback to ActionCreators and custom XHR calls just to read a header that isn't `'Content-Type'`