### PR TITLE
Move immutable to peer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
 test/build/*
+example/build/*
 build/*
 tmp
 .idea

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -24,6 +24,7 @@ var eslint = require('gulp-eslint');
 var webpack = require('webpack');
 var gulpWebpack = require('gulp-webpack');
 var webpackConfig = require('./webpack.config');
+var exampleWebpackConfig = require('./example/webpack.config');
 var testWebpackConfig = require('./test/webpack.config');
 var saveLicense = require('uglify-save-license');
 
@@ -47,6 +48,12 @@ gulp.task('mocha-test', function () {
     });
     stream.end();
     return stream;
+});
+
+gulp.task('build-example', function () {
+    return gulp.src(exampleWebpackConfig.entry.example)
+        .pipe(gulpWebpack(exampleWebpackConfig))
+        .pipe(gulp.dest(exampleWebpackConfig.output.path));
 });
 
 gulp.task('build-test', function () {
@@ -110,7 +117,7 @@ gulp.task('watch', function () {
 });
 
 gulp.task('clean', function () {
-    return gulp.src(['build/*', 'test/build/*'])
+    return gulp.src(['build/*', 'test/build/*', 'example/build/*'])
         .pipe(clean());
 });
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>Fluxthis Example</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="text/javascript" src="/build/example.js"></script>
+    </body>
+</html>

--- a/example/src/action-creator.js
+++ b/example/src/action-creator.js
@@ -1,0 +1,14 @@
+const FluxThis = require('../../build/FluxThis');
+const ActionCreator = FluxThis.ActionCreator;
+
+module.exports = new ActionCreator({
+    displayName: 'Counter',
+    increaseCounter: {
+        type: 'INCREASE_COUNTER',
+        payload: ActionCreator.PayloadTypes.number.isRequired
+    },
+    decreaseCounter: {
+        type: 'DECREASE_COUNTER',
+        payload: ActionCreator.PayloadTypes.number.isRequired
+    }
+});

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,0 +1,87 @@
+const React = require('react');
+const createReactClass = require('create-react-class');
+const CounterActionCreator = require('./action-creator');
+const CounterStore = require('./store');
+
+module.exports = createReactClass({
+    displayName: 'CounterApp',
+
+    mixins: [CounterStore.mixin],
+
+    getStateFromStores() {
+        return {
+            count: CounterStore.getCount()
+        };
+    },
+
+    decreaseCounterBy(value) {
+        return function () {
+            CounterActionCreator.decreaseCounter(value);
+        }
+    },
+
+    increaseCounterBy(value) {
+        return function () {
+            CounterActionCreator.increaseCounter(value);
+        }
+    },
+
+    render() {
+        return React.createElement(
+            'div',
+            { style: { width: 250, textAlign: 'center', margin: '0 auto' } },
+            React.createElement(
+                'p',
+                null,
+                React.createElement('strong', null, 'Current count:'),
+                ' ',
+                this.state.count
+            ),
+            React.createElement(
+                'div',
+                { style: { float: 'left' } },
+                React.createElement(
+                    'button',
+                    { onClick: this.decreaseCounterBy(5) },
+                    '-5'
+                )
+            ),
+            React.createElement(
+                'div',
+                { style: { float: 'left' } },
+                React.createElement(
+                    'button',
+                    { onClick: this.decreaseCounterBy(1) },
+                    '-1'
+                )
+            ),
+            React.createElement(
+                'div',
+                { style: { float: 'right' } },
+                React.createElement(
+                    'button',
+                    { onClick: this.increaseCounterBy(5) },
+                    '+5'
+                )
+            ),
+            React.createElement(
+                'div',
+                { style: { float: 'right' } },
+                React.createElement(
+                    'button',
+                    { onClick: this.increaseCounterBy(1) },
+                    '+1'
+                )
+            ),
+            React.createElement(
+                'hr',
+                { style: { clear: 'both' } }
+            ),
+            React.createElement(
+                'pre',
+                { style: { textAlign: 'left', whiteSpace: 'pre-wrap', wordWrap: 'break-word' } },
+                JSON.stringify(CounterStore.getState())
+            )
+        );
+    }
+});

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,0 +1,5 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const App = require('./app');
+
+ReactDOM.render(React.createElement(App, null), document.getElementById('root'));

--- a/example/src/store.js
+++ b/example/src/store.js
@@ -1,0 +1,37 @@
+const Immutable = require('immutable');
+const FluxThis = require('../../build/FluxThis');
+
+module.exports = new FluxThis.ImmutableReducerStore({
+    displayName: 'CounterStore',
+
+    init() {
+        this.defaultState = Immutable.List();
+
+        this.bindActions(
+            'INCREASE_COUNTER', this.increaseCounter,
+            'DECREASE_COUNTER', this.decreaseCounter
+        );
+    },
+
+    public: {
+        getState() {
+            return this.state;
+        },
+
+        getCount() {
+            return this.state.reduce(function (total, value) {
+                return total + value;
+            }, 0);
+        }
+    },
+
+    private: {
+        increaseCounter(state, increasedAmount) {
+            return state.push(increasedAmount);
+        },
+
+        decreaseCounter(state, decreasedAmount) {
+            return state.push(-1 * decreasedAmount);
+        }
+    }
+});

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,0 +1,31 @@
+var webpack = require('webpack');
+
+module.exports = {
+    cache: true,
+    entry: {
+        example: './example/src/index.js'
+    },
+    output: {
+        path: __dirname + '/build',
+        filename: 'example.js'
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env': {
+                NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
+            }
+        })
+    ],
+    resolve: {
+        root: __dirname,
+        extensions: ['', '.webpack.js', '.web.js', '.js'],
+        modulesDirectories: ['web_modules', 'node_modules']
+    },
+    module: {
+        loaders: [{
+            test: /\.es6\.js$/,
+            exclude: /node_modules/,
+            loader: 'babel-loader?optional[]=runtime'
+        }]
+    }
+};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "AddThis"
   ],
   "peerDependencies": {
-    "react": ">=0.13.2"
+    "immutable": "^3.7.1"
   },
   "devDependencies": {
     "babel": "^5.0.8",
@@ -51,6 +51,7 @@
     "gulp-mocha-phantomjs": "^0.12.2",
     "gulp-util": "^3.0.5",
     "gulp-webpack": "^1.3.1",
+    "immutable": "^3.8.2",
     "mocha": "^2.2.4",
     "mocha-phantomjs": "3.5.3",
     "phantomjs": "^1.9.17",
@@ -62,7 +63,6 @@
     "webpack": "^1.8.9"
   },
   "dependencies": {
-    "immutable": "^3.7.1",
     "invariant": "^2.0.0",
     "path-to-regexp": "^1.2.0",
     "proptypes": "^0.14.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,9 @@ module.exports = {
         library: 'FluxThis',
         libraryTarget: 'umd'
     },
+    externals: {
+        immutable: { commonjs2: 'immutable' }
+    },
     devtool: 'sourcemap',
     plugins: [
         new webpack.DefinePlugin({


### PR DESCRIPTION
This PR moves the immutable library to a peer dependency to allow application developers to make use of their existing immutable version, rather than having to bundle two (or be dependent on the version bundled in fluxthis). This reduces the overall fluxthis build size by over a third (see below).

### On Master
```
$ gulp build-prod
[12:27:02] Using gulpfile /fluxthis/gulpfile.js
[12:27:02] Starting 'build-prod'...
[12:27:05] Version: webpack 1.15.0
              Asset     Size  Chunks             Chunk Names
    FluxThis.min.js   156 kB       0  [emitted]  FluxThis
FluxThis.min.js.map  1.05 MB       0  [emitted]  FluxThis
[12:27:05] Finished 'build-prod' after 3.49 s
```

### This Branch
```
$ gulp build-prod
[12:26:28] Using gulpfile /fluxthis/gulpfile.js
[12:26:28] Starting 'build-prod'...
[12:26:30] Version: webpack 1.15.0
              Asset     Size  Chunks             Chunk Names
    FluxThis.min.js  99.3 kB       0  [emitted]  FluxThis
FluxThis.min.js.map   656 kB       0  [emitted]  FluxThis
[12:26:30] Finished 'build-prod' after 2.88 s
```

This PR also adds in an example application build to confirm that there should be no issues using fluxthis as normal with immutable removed, and confirming that webpack correctly bundles it within the overall application bundle. It can also serve as an example implementation of using fluxthis and react.
It is just a basic counter example, saving all changes to the counter in the store, and providing a public method to retrieve the overall total count.
![fluxthis-example](https://user-images.githubusercontent.com/635903/33230510-c1eb10c8-d1dc-11e7-920b-652b27dd7102.gif)
