### PR TITLE
Add support for setting private members during tests

### DIFF
--- a/src/StoreTestUtils.es6.js
+++ b/src/StoreTestUtils.es6.js
@@ -77,6 +77,18 @@ export default function (initializeStore,
 		},
 
 		/**
+		 * Set a private member within the context
+		 * of a store
+		 *
+		 * @param object
+		 */
+		setPrivateMembers(object) {
+			each(object, (key, value) => {
+				privateMembers[key] = value;
+			});
+		},
+
+		/**
 		 * Reset a store back to a clean state by clearing
 		 * out it's private members, and reinitializing it.
 		 */

--- a/test/src/object-oriented-store-tests.js
+++ b/test/src/object-oriented-store-tests.js
@@ -387,6 +387,21 @@ describe('ObjectOrientedStore', function () {
 			s.getThing().should.equal(privateAttribute);
 		});
 
+		it('should be able to set private members', function () {
+			var s = new Store(config);
+
+			Should.exist(s.TestUtils.setPrivateMembers);
+
+			s.TestUtils.setPrivateMembers({
+				thing: 'i am set'
+			});
+
+			s.getThing().should.equal('i am set');
+
+			s.TestUtils.reset();
+			s.getThing().should.equal(privateAttribute);
+		});
+
 		it('should be able to mock public method and reset just mocked public methods', function () {
 			var s = new Store(config);
 


### PR DESCRIPTION
This PR adds support for setting private members during tests, in a similar implementation to the existing `mockPublicMethods` function.

This will allow developers to follow the common testing pattern of [Arrange, Act, Assert](http://wiki.c2.com/?ArrangeActAssert) when developing Store tests.

In particular, it will allow for stores to be in a well defined and known state before dispatching an action, and asserting on the new state.

Documentation added https://github.com/addthis/fluxthis.io/pull/15