### PR TITLE
Allowing stores to have controller views that use the same display name.

### DIFF
--- a/src/Store.es6.js
+++ b/src/Store.es6.js
@@ -27,7 +27,6 @@ const CHANGE_LISTENERS = Symbol();
 export default class Store {
 	constructor(options) {
 		const store = this;
-		const ViewDisplayNames = new Set();
 
 		invariant(
 			options,
@@ -80,16 +79,6 @@ export default class Store {
 				);
 
 				invariant(
-					!ViewDisplayNames.has(displayName),
-					`Error: ${store.toString()} already has a ` +
-					'controller view registered with the display name ' +
-					`of ${displayName}. Please make sure ` +
-					'display names are unique.'
-				);
-
-				ViewDisplayNames.add(displayName);
-
-				invariant(
 					this.getStateFromStores instanceof Function,
 					'`%s` must define `getStateFromStores` in order to use ' +
 					'the FluxThis mixin.',
@@ -116,7 +105,6 @@ export default class Store {
 			componentWillUnmount() {
 				this.__fluxIsMounted = false;
 				renderedComponentSet.delete(this);
-				ViewDisplayNames.delete(this.constructor.displayName);
 				store.removeChangeListener(this.__fluxChangeListener);
 			},
 


### PR DESCRIPTION
This PR removes an invariant check which currently stops components with the same display name from acting as controller views for the same store.

I've been working around this particular check for a while, but as the application I work on grows in size and we try to reuse functionality, the more this invariant becomes a blocker. In our particular use case we started out with a small application with a single container at our top-level, but as our single-page application spread we found the need for page-specific containers. As functionality became shared across pages we then needed reusable connected components which is where this invariant reared it's head.

Example Scenario:
Sales reports that have various graphs upon them which are all data-driven from a store. The graphs functionality is separated into a reusable component which is connected to a flux store. Any tweaking of content is all handled via props. FluxThis wouldn't currently allow this generic component to be rendered more than once due to the invariant (as the component would have the same display name), but in my opinion it's a perfect valid use case to separate functionality into generic building block components and give them the ability to connect to a flux store.

From what I can gather in the source code, there's no requirement on display names being unique and it's merely a suggested convention. To better accommodate reusability of connected components I'd like to remove this particular invariance so connected components can be used more than once.