### PR TITLE
Call failure handler on network error

### DIFF
--- a/lib/implore.es6.js
+++ b/lib/implore.es6.js
@@ -49,6 +49,7 @@ export default function implore(request, callback) {
 
 	const {withCredentials=false, headers={}} = request;
 	const xhr = new XMLHttpRequest();
+	const xhrAbort = XMLHttpRequest.prototype.abort;
 
 	invariant(
 		request,
@@ -107,13 +108,17 @@ export default function implore(request, callback) {
 		}
 	}
 
-	xhr.onabort = function onabort() {
+	xhr.abort = function abort() {
 		callback({
 			request,
 			response: {
 				fluxthisAborted: true
 			}
 		});
+
+		// Avoid an additional call via onreadystatechange
+		xhr.onreadystatechange = null;
+		xhrAbort.call(this);
 	};
 
 	xhr.onreadystatechange = function onreadystatechange() {
@@ -143,6 +148,14 @@ export default function implore(request, callback) {
 					}
 				}
 			}
+
+			callback({
+				request,
+				response
+			});
+		} else if (xhr.readyState === 4 && xhr.status === 0) {
+			response.body = {};
+			response.status = 0;
 
 			callback({
 				request,


### PR DESCRIPTION
Fixes #149 

This PR resolves an existing issue where if there is a network error the failure handler was not getting called and the API call would remain in the `pending` state.
To resolve this issue, a further check has been added into `lib/implore.es6.js` on the `onreadystatechange` event handler. This check handles the scenario when `readystate` is 4 and `status` is 0 - this occurs when the network has failed.

Along with this, updates have been made to the `abort` functionality.
A `readystate` of 4 and `status` of 0 occurs when the user has manually aborted the xhr request as well. To avoid calling the callback twice, i.e. once during `abort` and once during `onreadystatechange`, I have overwritten the xhr `abort` method.
This method now calls the callback with the response of `fluxthisAborted: true` and sets the `onreadystatechange` to null, avoiding an additional call to this function, as well as calling the `xhr.abort` function.

It is important to note that ordering is guaranteed with this functionality as the `abort` method is the exposed method from xhr and we are just adding functionality while maintaining existing functionality.