### PR TITLE
Update qs package to address security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "invariant": "^2.0.0",
     "path-to-regexp": "^1.2.0",
     "proptypes": "^0.14.3",
-    "qs": "^3.1.0",
+    "qs": "^6.5.1",
     "warning": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Updates the qs package to `^6.5.1`
- Address security advisory (High severity): https://snyk.io/vuln/npm:qs:20170213

I'm using FluxThis on a project and Snyk raised the issue: https://snyk.io/test/npm/fluxthis?severity=high&severity=medium&severity=low

All tests continue to pass after updating this package. It's only used in one place and the API of the `qs` library hasn't changed for what Fluxthis uses it for.