### PR TITLE
Don't trigger failure reactions for non-failure events

### DIFF
--- a/src/APIActionCreator.es6.js
+++ b/src/APIActionCreator.es6.js
@@ -238,6 +238,7 @@ export default class APIActionCreator extends ActionCreator {
 				const {response, request} = result;
 				const success = successTest(response);
 				const isAborted = !!response.fluxthisAborted;
+				const isFailure = !success && !isAborted;
 
 				// These methods allow the user to process
 				// the request and modify it how they please
@@ -246,7 +247,7 @@ export default class APIActionCreator extends ActionCreator {
 					handleSuccess.call(this, request, response);
 				} else if (isAborted && handleAbort) {
 					handleAbort.call(this, request, response);
-				} else if (handleFailure) {
+				} else if (isFailure && handleFailure) {
 					handleFailure.call(this, request, response);
 				}
 
@@ -255,7 +256,7 @@ export default class APIActionCreator extends ActionCreator {
 					type = successActionType;
 				} else if (isAborted && abortActionType) {
 					type = abortActionType;
-				} else if (!success && failureActionType) {
+				} else if (isFailure && failureActionType) {
 					type = failureActionType;
 				}
 


### PR DESCRIPTION
This PR updates the `APIActionCreator` so that unintended actions/side-effects are not triggered when requests complete.

Previously, there were a couple of spots where mismatched actions or callbacks were being triggered:
- `handleFailure` could be called during success or abort actions, if the corresponding callbacks were not specified (ie: a success action without a handleSuccess, abort action without a handleAbort)
- The failure action could get dispatched when calling abort without a corresponding abort action

Test cases have been added to cover these scenarios, and the `send` callback has been updated.